### PR TITLE
mark overview tab as dirty the first time it's opened, to force `Save`

### DIFF
--- a/client/src/consts.js
+++ b/client/src/consts.js
@@ -82,7 +82,10 @@ export const dbDefaultSettings = {
       // turnStrategy: '',
       startTime: new Date().toISOString(),
       complete: false,
-      dirty: false,
+      // mark page as dirty the first time it's opened,
+      // in order to overwrite existing time
+      // values with the above defaults
+      dirty: true,
     },
     forces: {
       name: "Forces",


### PR DESCRIPTION
Fixes this:
https://trello.com/c/xMWX2K4C/60-wargame-validation-time