### PR TITLE
Show insights to all observers

### DIFF
--- a/client/src/Views/AdminAndInsightsTabsContainer.jsx
+++ b/client/src/Views/AdminAndInsightsTabsContainer.jsx
@@ -51,7 +51,7 @@ class AdminAndInsightsTabsContainer extends Component {
       FlexLayout.Actions.addNode({type: "tab", component: this.state.gameAdmin, name: this.state.gameAdmin, id: this.state.gameAdmin}, "#2", FlexLayout.DockLocation.CENTER, -1)
     );
 
-    if (this.props.playerUi.controlUi) {
+    if (this.props.playerUi.isObserver) {
       this.state.model.doAction(
         FlexLayout.Actions.addNode({type: "tab", component: this.state.insights, name: this.state.insights, id: this.state.insights}, "#2", FlexLayout.DockLocation.CENTER, -1)
       );

--- a/client/src/Views/InsightsChannel.jsx
+++ b/client/src/Views/InsightsChannel.jsx
@@ -5,6 +5,7 @@ import {
   getAllWargameFeedback,
 } from "../ActionsAndReducers/playerUi/playerUi_ActionCreators";
 import '../scss/App.scss';
+import moment from "moment";
 
 class InsightsChannel extends Component {
 
@@ -39,6 +40,7 @@ class InsightsChannel extends Component {
                 <Badge pill variant="primary">{message.playerInfo.force}</Badge> 
                 <Badge pill variant="secondary">{message.playerInfo.role}</Badge>
                 {message.playerInfo.name && <Badge pill variant="warning">{message.playerInfo.name}</Badge>}
+                <span>{moment(message.timestamp).format("YYYY-MMM-DD HH:mm")}</span>
               </div>
               {message.message}
               <p className="feedback-marker"  style={{borderColor: message.playerInfo.forceColor}}></p>

--- a/client/src/api/wargames_api.js
+++ b/client/src/api/wargames_api.js
@@ -839,6 +839,7 @@ export const postFeedback = (dbName, playerInfo, message) => {
       _id: new Date().toISOString(),
       playerInfo,
       message,
+      timestamp: new Date().toISOString(),
       feedback: true,
     })
       .then((res) => {


### PR DESCRIPTION
Until we have flag to indicate specific roles that can view insight/feedback, use `isObserver` flag to decide who sees Game Insights, rather than just the GameControl role.