### PR TITLE
Feedback fix

### DIFF
--- a/client/src/api/wargames_api.js
+++ b/client/src/api/wargames_api.js
@@ -840,7 +840,7 @@ export const postFeedback = (dbName, fromDetails, message) => {
       details: {
         channel: "Feedback",
         from: fromDetails,
-        messageType: "Feedback",
+        messageType: "Chat",
         timestamp: new Date().toISOString(),
       },
       message: {


### PR DESCRIPTION
The Excel export is looping through the message types in the Messages Editor.

But, we don't (currently) have a template for Feedback Message.  So, feedback messages weren't getting caught. Now they are.